### PR TITLE
Fix script/setup error

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -2,6 +2,8 @@
 set -e
 cd "`dirname \"$0\"`/.."
 
+brew tap homebrew/homebrew-php
+
 # http://www.smddzcy.com/2016/01/installing-configuring-php7-zts-on-os-x/
 (php -v | grep 'PHP 7.0') || brew install php70 --with-thread-safety --with-phpdbg
 


### PR DESCRIPTION
`script/setup` fails because homebrew doesn't know about the PHP70 brew. We need to tap the relevant repository to make it findable.