### PR TITLE
Fix a monolog call that masked underlying exceptions

### DIFF
--- a/lib/Agent.php
+++ b/lib/Agent.php
@@ -437,7 +437,7 @@ class Agent
                 return $address;
             }
         } catch (\Throwable $e) {
-            $this->log->warn("Couldn't resolve address for $host:$port", "warn");
+            $this->log->warn("Couldn't resolve address for $host:$port");
             $this->report_exception($e);
             return null;
         }


### PR DESCRIPTION
When DNS resolution failed we logged a message. Unfortunately the
logger call had an incorrect argument and would then raise a new
exception.

This removes the bad argument and adds a test to verify the correct
message gets logged.

https://github.com/Instrumental/instrumental_agent-php/issues/3